### PR TITLE
Exclude `/usr/lib/unifi/run` from docker volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **23.01.23:** - Exclude `run` from `/config` volume.
 * **30.11.22:** - Bump JRE to 11.
 * **01.06.22:** - Deprecate armhf.
 * **23.12.21:** - Move min/max memory config from run to system.properties.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -66,6 +66,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "23.01.23:", desc: "Exclude `run` from `/config` volume."}
   - { date: "30.11.22:", desc: "Bump JRE to 11."}
   - { date: "01.06.22:", desc: "Deprecate armhf."}
   - { date: "23.12.21:", desc: "Move min/max memory config from run to system.properties."}

--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -2,14 +2,13 @@
 
 # create our folders
 mkdir -p \
-    /config/{data,logs,run}
+    /config/{data,logs}
 
 
 # create symlinks for config
 symlinks=( \
 /usr/lib/unifi/data \
-/usr/lib/unifi/logs \
-/usr/lib/unifi/run )
+/usr/lib/unifi/logs )
 
 for i in "${symlinks[@]}"
 do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ ] I have read the [contributing](https://github.com/linuxserver/docker-unifi-controller/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
It seems if the underlying file system of the mounted `/config` volume is incompatible with unix sockets, mongodb will not be able to start the listener.

The best way is to keep the whole `run` folder within the container itself. The other files in that folder are also ephemeral and no persistence is required.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This PR simply removes the `run` folder from being symlinked into the `/config` volume.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I was not able to reproduce the problem as I don't have a incompatible environment. But this PR works as intended.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
closes #166 #183
